### PR TITLE
Add support for MozillaTTS engine

### DIFF
--- a/src/modules/tts/index.ts
+++ b/src/modules/tts/index.ts
@@ -39,6 +39,36 @@ export async function initEngines(addon: Addon) {
         }
     )
 
+    addon.data.tts.current = "mozillaTTS"
+
+    let mozTTSPromise = import("./mozillaTTS").then(
+        (e) => {
+            addon.data.tts.engines["mozillaTTS"] = {
+                name: "Mozilla Text-to-Speech for all.",
+                status: "loading",
+                speak: e.speak,
+                stop: e.stop,
+                canPause: false,
+                pause: e.pause,
+                resume: e.resume,
+                extras: {
+                }
+            }
+
+            return e
+        }
+    ).then(
+        (e) => {
+            addon.data.tts.engines["mozillaTTS"].status = "ready"
+        }
+    )
+    .catch(
+        (e) => {
+            // ztoolkit.log(`WSA init fail - ${e}`)
+            addon.data.tts.engines["mozillaTTS"].status = "error"
+        }
+    )
+
     // TODO: future - implement more engines
     //   Google?
     //   Azure?
@@ -48,6 +78,7 @@ export async function initEngines(addon: Addon) {
     try {
         await Promise.any([
             wsaPromise,
+            mozTTSPromise
             // TODO: future - other engines promises here
         ])
         addon.data.tts.status = "ready"

--- a/src/modules/tts/mozillaTTS.ts
+++ b/src/modules/tts/mozillaTTS.ts
@@ -1,0 +1,68 @@
+const audioContext = new window.AudioContext();
+
+async function getAudio(text: string) {
+    return Zotero.HTTP.request("GET", `http://localhost:5002/api/tts?text=${encodeURI(text)}`, {"responseType": "arraybuffer", "timeout":120000})
+    .then((request) => request.response)
+    .then((buff) => audioContext.decodeAudioData(buff))
+}
+
+
+async function speak(text: string) {
+    var sentences = text.match( /[^\.!\?]+[\.!\?]+/g ) ?? []
+    
+    var sentences_buff: Record<number, AudioBuffer> = []
+    sentences.forEach((v, i) => {getAudio(v.trim()).then((buff) => sentences_buff[i]=buff)})
+
+    var currentSource: AudioBufferSourceNode;
+    var endTime = 0;
+    const qued_idxs: number[] = []
+    
+    var current_idx = 0 
+    const playingInterval = setInterval(() => {
+        // Zotero.log(`end: ${endTime}`)
+        // Zotero.log(`now: ${audioContext.currentTime}`)
+
+        if (current_idx > sentences.length - 1) {
+            clearInterval(playingInterval)
+            // Zotero.log("done.")
+        }
+
+        if ((current_idx in sentences_buff) && !(current_idx in qued_idxs)) {
+            currentSource = audioContext.createBufferSource();
+            currentSource.buffer = sentences_buff[current_idx]
+            qued_idxs.push(current_idx)
+        }
+
+        if (currentSource) {
+            if ((audioContext.currentTime > endTime) || (current_idx == 0)) {
+                currentSource.connect(audioContext.destination)
+                currentSource.start()
+                endTime = audioContext.currentTime + sentences_buff[current_idx].duration
+                current_idx++;
+            }
+        }
+
+    }, 500)
+
+    // Zotero.log("intervalling")
+    
+}
+
+function stop() {
+    audioContext.suspend()
+}
+
+function pause() {
+    audioContext.suspend()
+}
+
+function resume() {
+    audioContext.resume()
+}
+
+export {
+    speak,
+    stop,
+    pause,
+    resume,
+}

--- a/src/modules/utils/prefs.ts
+++ b/src/modules/utils/prefs.ts
@@ -14,6 +14,6 @@ export function clearPref(key: string) {
 
 export function setDefaultPrefs() {
     if (!getPref("ttsEngine.current")) {
-        setPref("ttsEngine.current", "webSpeech")
+        setPref("ttsEngine.current", "mozillaTTS")
     }
 }


### PR DESCRIPTION
This is a working PR so far it is a minimum viable product and lacks preferences.

How to run, install mozilla-tts with python as in [these instructions](https://github.com/mozilla/TTS?tab=readme-ov-file#install-tts) (`pip install TTS`). Run the tts server (with default port, 5002), `tts-server`. There will be a small pause as the first query returns, but then should run smoothly

TODO:
- [ ] Fix up sentence chunking.
- [ ] Ignore or merge singlew word requests (mozilla-tss kinda mangles this request)
- [ ] Fix preferences page
- [ ] Fix play pause and all those extra goodies
- [ ] any  type of error handling on the tts api side